### PR TITLE
Change mcflirt to use number of frames in mc_tmp-1

### DIFF
--- a/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/CBIG_preproc_fslmcflirt_outliers.csh
+++ b/stable_projects/preprocessing/CBIG_fMRI_Preproc2016/CBIG_preproc_fslmcflirt_outliers.csh
@@ -183,8 +183,9 @@ foreach curr_bold ($zpdbold)
 		echo $cmd |& tee -a $LF
 		eval $cmd >> $LF
 		mv $boldfile"_mc.nii.gz" $boldfile"_mc_tmp.nii.gz"
-		set numof_tps = `fslnvols $boldfile".nii.gz"` 
-		fslroi $boldfile"_mc_tmp" $boldfile"_mc" 1 $numof_tps |& tee -a $LF
+		set numof_tps = `fslnvols $boldfile"_mc_tmp"`
+		set numof_tps = `echo "$numof_tps-1" | bc`
+		fslroi $boldfile"_mc_tmp" $boldfile"_mc" 0 $numof_tps |& tee -a $LF
 		rm $boldfile"_mc_tmp.nii.gz"
 	else
 		echo "=======================mcflirt and split already done!=======================" |& tee -a $LF


### PR DESCRIPTION
Change the mcflirt step to extract ROIs using # of mc_tmp frames - 1. It isn't entirely clear to me what difference it makes, but it does make a clear difference in the output. We should review this at some point to decide whether to keep Stephan's code or use the updated mainline CBIG code.